### PR TITLE
Updated getBoardResult to fix end result bug

### DIFF
--- a/framework/include/GameBoard.h
+++ b/framework/include/GameBoard.h
@@ -28,7 +28,8 @@ public:
     Game::movecount_t getMoves(Game::movelist_t& movesOut, Player::playernum_t playerNum);
 
     // Return the board result
-    Game::boardresult_t getBoardResult();
+    // Current player number is needed for some games
+    Game::boardresult_t getBoardResult(Player::playernum_t currentPlayerNum);
 
     // Return the state of the board in string format
     std::string getBoardStateString();

--- a/framework/src/RandomPlayer.cpp
+++ b/framework/src/RandomPlayer.cpp
@@ -20,11 +20,18 @@ Game::move_t RandomPlayer::selectMove(Game::GameBoard& board, playernum_t player
     Game::movelist_t moveList;
     Game::movecount_t count = board.getMoves(moveList, playerNum);
     
-    // Get random move index
-    Game::movecount_t randomValue = (rand() % count);
+    // Prevent floating point exceptions
+    if(count > 0)
+    {
+        // Get random move index
+        Game::movecount_t randomValue = (rand() % count);
 
-    // Return random move
-    return moveList[randomValue];
+        // Return random move
+        return moveList[randomValue];
+    }
+
+    // Return empty move
+    return Game::move_t();
 }
 
 }

--- a/games/mancala/src/GameBoard.cpp
+++ b/games/mancala/src/GameBoard.cpp
@@ -143,7 +143,8 @@ movecount_t GameBoard::getMoves(movelist_t& movesOut, Player::playernum_t player
 }
 
 // Return the board result
-boardresult_t GameBoard::getBoardResult()
+// Current player number is needed for some games
+boardresult_t GameBoard::getBoardResult(Player::playernum_t currentPlayerNum)
 {
     // Set initial board state
     boardresult_t boardResult = GAME_ACTIVE;
@@ -162,7 +163,8 @@ boardresult_t GameBoard::getBoardResult()
     }
 
     // Check if game is over
-    boardResult = ((p1SideValue == 0) || (p2SideValue == 0));
+    boardResult = (((p1SideValue == 0)*(currentPlayerNum == Player::PLAYER_NUMBER_1)) || 
+                    ((p2SideValue == 0)*(currentPlayerNum == Player::PLAYER_NUMBER_2)));
 
     // If game over, move all pieces to goals
     boardState[P1_GOAL] += p1SideValue*boardResult;

--- a/simulation/src/main.cpp
+++ b/simulation/src/main.cpp
@@ -43,9 +43,9 @@ int main(int argc, char **argv)
               << "Beginning game state:" << std::endl 
               << gameBoard.getBoardStateString() << std::endl << std::endl;
 
-    bool gameActive = true;
     Player::playernum_t activePlayer = Player::PLAYER_NUMBER_1;
-    while(gameActive)
+    Game::boardresult_t gameResult = Game::GAME_ACTIVE;
+    while(gameResult == Game::GAME_ACTIVE)
     {
         // Get move from player
         Game::move_t move = playerManager.getMove(activePlayer, gameBoard);
@@ -53,44 +53,34 @@ int main(int argc, char **argv)
         // Make move on board
         Game::moveresult_t moveResult = gameBoard.executeMove(move, activePlayer);
 
+        // Verify valid move result
+        if(!moveResult)
+        {
+            std::cout << "[ERROR] Incorrect move for player " << std::to_string(activePlayer) 
+                        << " given: " << std::to_string(move) << std::endl;
+            return 1;
+        }
+
+        // Print move and new board state
+        std::cout   << "Player " << std::to_string(activePlayer + 1)
+                    << " Makes Move: " << std::to_string(move) << std::endl 
+                    << "New board state:" << std::endl 
+                    << gameBoard.getBoardStateString() << std::endl << std::endl;
+
+        // Check move result
+        if(moveResult == Game::MOVE_SUCCESS)
+        {
+            // Switch players
+            activePlayer = !activePlayer;
+
+        }
+
         // Check if in end state
-        Game::boardresult_t gameResult = gameBoard.getBoardResult();
-
-        // Check game result
-        if(gameResult)
-        {
-            // If game over, stop game
-            gameActive = false;
-        }
-        else
-        {
-            // Check move result
-            if(!moveResult)
-            {
-                std::cout << "[ERROR] Incorrect move for player " << std::to_string(activePlayer) 
-                          << " given: " << std::to_string(move) << std::endl;
-                return 1;
-            }
-            else
-            {
-                // Print move and new board state
-                std::cout << "Player " << std::to_string(activePlayer + 1)
-                          << " Makes Move: " << std::to_string(move) << std::endl 
-                          << "New board state:" << std::endl 
-                          << gameBoard.getBoardStateString() << std::endl << std::endl;
-                if(moveResult == Game::MOVE_SUCCESS)
-                {
-                    // Switch players
-                    activePlayer = !activePlayer;
-
-                }
-            }
-        }
+        gameResult = gameBoard.getBoardResult(activePlayer);
         
     }
 
     // Output game win
-    Game::boardresult_t gameResult = gameBoard.getBoardResult();
     switch(gameResult)
     {
         case Game::GAME_OVER_PLAYER1_WIN:


### PR DESCRIPTION
Fixes three major problems:
1. getBoardResult did not know who's turn it was, so it could not determine an end state properly
2. getBoardResult was called at the wrong time in the simulation, so it was possible for a MOVE_SUCCESS_GO_AGAIN to not properly determine that the game was over, causing the Player to attempt to do another move instead of ending the game.
3. getMove for the RandomPlayer did not have bounds checking, so a floating point error was allowed to occur when no moves where generated.