### PR TITLE
17 gpu simulation optimizations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ clean:
 # Launches run script
 run: build/bin/simulation
 	@rm -f *.nsys-rep *.i* *.o* core.*
-	@echo -ne "gpu\n4\n\n2gb\n1\nampere\ngame_simulation\n" | \
+	@echo -ne "class\n4\n\n2gb\n1\nampere\ngame_simulation\n" | \
 		run_gpu .runSimulation.sh > /dev/null
 	@sleep 5
 	@tail -f *.o*

--- a/framework/include/MonteCarloPlayer.h
+++ b/framework/include/MonteCarloPlayer.h
@@ -65,6 +65,7 @@ protected:
     double m_explorationParam = 1;
     int m_numIterations = 1000;
     std::vector<MonteCarlo::SimulationPerformanceReport> m_simulationReports;
+    std::vector<double> m_executionTimes;
 
 private:
     void runSearch();

--- a/framework/include/MonteCarloTypes.h
+++ b/framework/include/MonteCarloTypes.h
@@ -87,7 +87,7 @@ static int getMaxNode(std::vector<std::shared_ptr<TreeNode>> nodeList) {
         if(nodeList[i]->numTimesVisited == 0) {
             continue;
         }
-        else if(nodeList[i]->value > nodeList[maxNode]->value) {
+        else if(nodeList[i]->numWins > nodeList[maxNode]->numWins) {
             maxNode = i;
         }
     }
@@ -99,7 +99,7 @@ static int getMaxNode(std::vector<std::shared_ptr<TreeNode>> nodeList) {
 // UCT is Upper Confidence Bound for Trees
 static void calculateValue(std::shared_ptr<TreeNode> node, unsigned int rootVisits, double explorationParam) {
     double avg = node->numWins / node->numTimesVisited;
-    node->value = avg + explorationParam*sqrt(log(rootVisits) / node->numTimesVisited);
+    node->value = avg + (explorationParam*sqrt(log(rootVisits) / node->numTimesVisited));
 }
 
 // Report given at the end of each simulation cycle

--- a/framework/include/MonteCarloUtility.h
+++ b/framework/include/MonteCarloUtility.h
@@ -4,7 +4,7 @@
 #include "GameTypes.h"
 #include "GameBoard.h"
 
-#define BLOCK_SIZE 200 // max thread count per block
+#define BLOCK_SIZE 1024 // max thread count per block
 #define GRID_SIZE 2 // 2 blocks of 1024 threads
 
 // Note: For future use

--- a/framework/include/MonteCarloUtility.h
+++ b/framework/include/MonteCarloUtility.h
@@ -4,8 +4,8 @@
 #include "GameTypes.h"
 #include "GameBoard.h"
 
-#define BLOCK_SIZE 200 // max thread count per block
-#define GRID_SIZE 1 // 2 blocks of 1024 threads
+#define BLOCK_SIZE 1024 // max thread count per block
+#define GRID_SIZE 2 // 2 blocks of 1024 threads
 
 // Note: For future use
 // Launch configurator says 576 block size and 216 grid size for max launch
@@ -29,8 +29,6 @@ struct deterministic_data
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-void curandInit();
 
 void simulationGPU(
     gpu_result* gpu_result_out,

--- a/framework/include/MonteCarloUtility.h
+++ b/framework/include/MonteCarloUtility.h
@@ -4,12 +4,12 @@
 #include "GameTypes.h"
 #include "GameBoard.h"
 
-#define BLOCK_SIZE 128
-#define PLAYCOUNT_THRESHOLD_GPU 200
+#define BLOCK_SIZE 200 // max thread count per block
+#define GRID_SIZE 2 // 2 blocks of 1024 threads
 
 // Note: For future use
 // Launch configurator says 576 block size and 216 grid size for max launch
-#define GRID_SIZE 216
+//#define GRID_SIZE 216
 #define LAUNCH_SIZE (BLOCK_SIZE * GRID_SIZE)
 
 typedef unsigned int gpu_count_t;

--- a/framework/include/MonteCarloUtility.h
+++ b/framework/include/MonteCarloUtility.h
@@ -4,8 +4,8 @@
 #include "GameTypes.h"
 #include "GameBoard.h"
 
-#define BLOCK_SIZE 1024 // max thread count per block
-#define GRID_SIZE 2 // 2 blocks of 1024 threads
+#define BLOCK_SIZE 200 // max thread count per block
+#define GRID_SIZE 1 // 2 blocks of 1024 threads
 
 // Note: For future use
 // Launch configurator says 576 block size and 216 grid size for max launch

--- a/framework/src/MonteCarloHybridPlayer.cpp
+++ b/framework/src/MonteCarloHybridPlayer.cpp
@@ -12,7 +12,6 @@ MonteCarloHybridPlayer::MonteCarloHybridPlayer()
     m_numIterations = 250;
 
     // Init curand values
-    curandInit();
     m_explorationParam = 0;
     setDeterministic(false, 0);
 }

--- a/framework/src/MonteCarloPlayer.cpp
+++ b/framework/src/MonteCarloPlayer.cpp
@@ -15,6 +15,8 @@ MonteCarloPlayer::MonteCarloPlayer()
 // Select a move from the given boardstate
 Game::move_t MonteCarloPlayer::selectMove(Game::GameBoard& board, playernum_t playerNum)
 {
+    Timer timer;
+    timer.start();
     m_rootNode = std::shared_ptr<MonteCarlo::TreeNode>(new MonteCarlo::TreeNode());
     m_rootNode->boardState = board;
     m_rootNode->playerNum = playerNum;
@@ -27,6 +29,9 @@ Game::move_t MonteCarloPlayer::selectMove(Game::GameBoard& board, playernum_t pl
     board.getMoves(moveList, playerNum);
 
     int maxNode = MonteCarlo::getMaxNode(m_rootNode->childNodes);
+
+    timer.stop();
+    m_executionTimes.push_back(timer.elapsedTime_ms() / 1000);
 
     return moveList[maxNode];
 }
@@ -174,6 +179,15 @@ std::string MonteCarloPlayer::getPerformanceDataString() {
     double averageExecutionTime = executionTimeAggregate / numSimulations;
     double movesPerSecond = numMovesSimulatedAggregate / (executionTimeAggregate / 1000);
 
+    double timeAggregate = 0;
+    for(auto time : m_executionTimes)
+    {
+        timeAggregate += time;
+    }
+    double avgTurnExecutionTime = timeAggregate / m_executionTimes.size();
+    
+
+    out << "\tAverage Execution Time Per Turn - " << avgTurnExecutionTime << std::endl;
     out << "\tAverage Execution Time (For Simulation Step) - " << averageExecutionTime << std::endl;
     out << "\tMoves Simulated Per Second - " << movesPerSecond << std::endl;
 

--- a/framework/src/MonteCarloPlayer.cpp
+++ b/framework/src/MonteCarloPlayer.cpp
@@ -176,7 +176,7 @@ std::string MonteCarloPlayer::getPerformanceDataString() {
         executionTimeAggregate += (report.executionTime / 1000);
         numMovesSimulatedAggregate += report.numMovesSimulated;
     }
-    double averageExecutionTime = executionTimeAggregate / numSimulations;
+    double averageExecutionTime = (executionTimeAggregate / numSimulations)*m_numIterations;
     double movesPerSecond = numMovesSimulatedAggregate / executionTimeAggregate;
 
     double timeAggregate = 0;

--- a/framework/src/MonteCarloPlayer.cpp
+++ b/framework/src/MonteCarloPlayer.cpp
@@ -31,7 +31,7 @@ Game::move_t MonteCarloPlayer::selectMove(Game::GameBoard& board, playernum_t pl
     int maxNode = MonteCarlo::getMaxNode(m_rootNode->childNodes);
 
     timer.stop();
-    m_executionTimes.push_back(timer.elapsedTime_ms() / 1000);
+    m_executionTimes.push_back(timer.elapsedTime_ms());
 
     return moveList[maxNode];
 }
@@ -173,16 +173,16 @@ std::string MonteCarloPlayer::getPerformanceDataString() {
     unsigned int numMovesSimulatedAggregate = 0;
     for(auto report : m_simulationReports) {
         ++numSimulations;
-        executionTimeAggregate += report.executionTime;
+        executionTimeAggregate += (report.executionTime / 1000);
         numMovesSimulatedAggregate += report.numMovesSimulated;
     }
     double averageExecutionTime = executionTimeAggregate / numSimulations;
-    double movesPerSecond = numMovesSimulatedAggregate / (executionTimeAggregate / 1000);
+    double movesPerSecond = numMovesSimulatedAggregate / executionTimeAggregate;
 
     double timeAggregate = 0;
     for(auto time : m_executionTimes)
     {
-        timeAggregate += time;
+        timeAggregate += (time / 1000);
     }
     double avgTurnExecutionTime = timeAggregate / m_executionTimes.size();
     

--- a/framework/src/MonteCarloUtility.cu
+++ b/framework/src/MonteCarloUtility.cu
@@ -1,6 +1,7 @@
 #include "MonteCarloUtility.h"
 
 #include <ctime>
+#include <iostream>
 
 #include <cuda_runtime.h>
 #include <curand_kernel.h>
@@ -9,14 +10,16 @@
 __device__ __constant__ Player::playernum_t initPlayerTurn;
 __device__ __constant__ Game::GameBoard initalGameBoard;
 __device__ gpu_result gpuResultGlobal;
-__device__ curandState_t curandStatesGlobal[BLOCK_SIZE];
+__device__ curandState_t curandStatesGlobal[BLOCK_SIZE*GRID_SIZE];
 __device__ deterministic_data deterministicData;
 
 // Kernel to init curand
 __global__ void curandInitKernel(unsigned long long seed)
 {
+    unsigned int idx = blockDim.x*blockIdx.x + threadIdx.x;
+    seed += idx;
     // Init curand states
-    curand_init(seed, threadIdx.x, 0, &curandStatesGlobal[threadIdx.x]);
+    curand_init(seed, 0, 0, &curandStatesGlobal[idx]);
 }
 
 __global__ void simulationKernel()
@@ -28,24 +31,25 @@ __global__ void simulationKernel()
     // number of moves simulated by this thread
     unsigned int numMovesSimulated = 0;
 
+    unsigned int idx = blockDim.x*blockIdx.x + threadIdx.x;
+
     // Init result to 0
     if(threadIdx.x == 0)
         gpuResultLocal = {};
+
     __syncthreads();
 
     // Grab curand state 
-    curandState_t curandStateLocal = curandStatesGlobal[threadIdx.x];
+    curandState_t curandStateLocal = curandStatesGlobal[idx];
 
     // Init search states
     Player::playernum_t currentPlayerTurn = initPlayerTurn;
     Game::GameBoard currentBoardState = initalGameBoard;
-    Game::boardresult_t currentBoardResult = Game::GAME_ACTIVE;
+    Game::boardresult_t currentBoardResult = currentBoardState.getBoardResult(currentPlayerTurn);
 
-    // Do simulations until threshold reached
-    while(gpuResultLocal.playCount < PLAYCOUNT_THRESHOLD_GPU)
+    // Pick random move and execute
+    while(currentBoardResult == Game::GAME_ACTIVE) 
     {
-        // Pick random move and execute
-
         // Get list of possible moves
         Game::movelist_t moveList;
         Game::movecount_t moveCount = currentBoardState.getMoves(moveList, currentPlayerTurn);
@@ -65,7 +69,7 @@ __global__ void simulationKernel()
             {
                 selectedMove = moveList[curand(&curandStateLocal) % moveCount];
             }
-             
+                
             // Execute random move
             Game::moveresult_t moveResult = currentBoardState.executeMove(selectedMove, currentPlayerTurn);
             ++numMovesSimulated;
@@ -80,48 +84,43 @@ __global__ void simulationKernel()
                 }
             }
         }
-        
+    
         // Check if game has ended
         currentBoardResult = currentBoardState.getBoardResult(currentPlayerTurn);
-        if(currentBoardResult != Game::GAME_ACTIVE)
+
+        // Game has ended, make sure board result has clear winner
+        if(currentBoardResult == Game::GAME_OVER_PLAYER1_WIN || 
+            currentBoardResult == Game::GAME_OVER_PLAYER2_WIN)
         {
-            // Game has ended, make sure board result has clear winner
-            if(currentBoardResult == Game::GAME_OVER_PLAYER1_WIN || 
-                currentBoardResult == Game::GAME_OVER_PLAYER2_WIN)
-            {
-                // If winner, count player win
-                gpuResultLocal.winCount[currentBoardResult - 1]++;
-            }
-
-            // Count playout
-            gpuResultLocal.playCount++;
-
-            // Reset search board states
-            currentPlayerTurn = initPlayerTurn;
-            currentBoardState = initalGameBoard;
+            // If winner, count player win
+            atomicAdd(&gpuResultLocal.winCount[currentBoardResult - 1], 1);
         }
-
-        // Sync threads before next stage
-        // Prevents reading and writing at same time
-        __syncthreads();
     }
 
+    // Count playout
+    atomicAdd(&gpuResultLocal.playCount, 1);
+
     // Save rng state
-    curandStatesGlobal[threadIdx.x] = curandStateLocal;
+    curandStatesGlobal[idx] = curandStateLocal;
 
     atomicAdd(&gpuResultLocal.numMovesSimulated, numMovesSimulated);
     __syncthreads();
 
     // Copy gpu result out
     if(threadIdx.x == 0)
-        gpuResultGlobal = gpuResultLocal;
+    {
+        atomicAdd(&gpuResultGlobal.winCount[0], gpuResultLocal.winCount[0]);
+        atomicAdd(&gpuResultGlobal.winCount[1], gpuResultLocal.winCount[1]);
+        atomicAdd(&gpuResultGlobal.playCount, gpuResultLocal.playCount);
+        atomicAdd(&gpuResultGlobal.numMovesSimulated, gpuResultLocal.numMovesSimulated);
+    }
     __syncthreads();
 }
 
 void curandInit()
 {
     // Init curand
-    curandInitKernel<<<1, BLOCK_SIZE>>>(time(NULL));
+    curandInitKernel<<<GRID_SIZE, BLOCK_SIZE>>>(time(NULL));
     checkCudaErrors(cudaGetLastError());
 }
 
@@ -131,9 +130,11 @@ void simulationGPU(gpu_result* gpu_result_out, Game::GameBoard gameBoard, Player
     checkCudaErrors(cudaMemcpyToSymbol(initalGameBoard, &gameBoard, sizeof(Game::GameBoard)));
     checkCudaErrors(cudaMemcpyToSymbol(initPlayerTurn, &playerTurn, sizeof(Player::playernum_t)));
     checkCudaErrors(cudaMemcpyToSymbol(deterministicData, &deterministicDataHost, sizeof(deterministic_data)));
+    gpu_result gpuResult = {};
+    checkCudaErrors(cudaMemcpyToSymbol(gpuResultGlobal, &gpuResult, sizeof(gpu_result)));
 
     // Launch kernel
-    simulationKernel<<<1, BLOCK_SIZE>>>();
+    simulationKernel<<<GRID_SIZE, BLOCK_SIZE>>>();
     checkCudaErrors(cudaGetLastError());
 
     // Copy result back

--- a/framework/src/PureMonteCarloPlayer.cpp
+++ b/framework/src/PureMonteCarloPlayer.cpp
@@ -11,7 +11,6 @@ namespace Player {
 PureMonteCarloPlayer::PureMonteCarloPlayer()
 {
     setDeterministic(false, 0);
-    curandInit();
 }
 
 // Select a move from the given boardstate

--- a/framework/src/PureMonteCarloPlayer.cpp
+++ b/framework/src/PureMonteCarloPlayer.cpp
@@ -116,11 +116,11 @@ std::string PureMonteCarloPlayer::getPerformanceDataString() {
     unsigned int numMovesSimulatedAggregate = 0;
     for(auto report : m_simulationReports) {
         ++numSimulations;
-        executionTimeAggregate += report.executionTime;
+        executionTimeAggregate += (report.executionTime / 1000);
         numMovesSimulatedAggregate += report.numMovesSimulated;
     }
     double averageExecutionTime = executionTimeAggregate / numSimulations;
-    double movesPerSecond = numMovesSimulatedAggregate / (executionTimeAggregate / 1000);
+    double movesPerSecond = numMovesSimulatedAggregate / executionTimeAggregate;
 
     double turnTimesAggregate = 0;
     for(auto turnTime : m_executionTimes)

--- a/framework/test/mcts/MonteCarloTreeSearchTests.cpp
+++ b/framework/test/mcts/MonteCarloTreeSearchTests.cpp
@@ -381,7 +381,7 @@ void pureMonteCarloTest()
     uut.simulateMove(moveNum, simulationResults_uut, simulationNumMoves_uut);
 
     bool pass = false;
-    if(simulationResults_ref*PLAYCOUNT_THRESHOLD_GPU == simulationResults_uut[0])
+    if(simulationResults_ref*LAUNCH_SIZE == simulationResults_uut[0])
     {
         pass = true;
     }

--- a/framework/test/mcts/MonteCarloTreeSearchTests.cpp
+++ b/framework/test/mcts/MonteCarloTreeSearchTests.cpp
@@ -304,10 +304,14 @@ void backpropagationTest()
     uutMT.backpropagation();
     uutGPU.backpropagation();
 
-    double relErrMT = (referenceNode->value - uutMTNode->value)*(referenceNode->value - uutMTNode->value) 
-                        + (referenceNode2->value - uutMTNode2->value)*(referenceNode2->value - uutMTNode2->value);
-    double relErrGPU = (referenceNode->value - uutGPUNode->value)*(referenceNode->value - uutGPUNode->value) 
-                        + (referenceNode2->value - uutGPUNode2->value)*(referenceNode2->value - uutGPUNode2->value);
+    double referenceNormSquared = referenceNode->value * referenceNode->value;
+    double diffMTNormSquared = (referenceNode->value - uutMTNode->value)*(referenceNode->value - uutMTNode->value) 
+                                + (referenceNode2->value - uutMTNode2->value)*(referenceNode2->value - uutMTNode2->value);
+    double diffGPUNormSquared = (referenceNode->value - uutGPUNode->value)*(referenceNode->value - uutGPUNode->value) 
+                                + (referenceNode2->value - uutGPUNode2->value)*(referenceNode2->value - uutGPUNode2->value);
+
+    double relErrMT = sqrt(diffMTNormSquared / referenceNormSquared);
+    double relErrGPU = sqrt(diffGPUNormSquared / referenceNormSquared);
 
     std::stringstream out("");
 

--- a/games/checkers/src/GameBoard.cpp
+++ b/games/checkers/src/GameBoard.cpp
@@ -313,4 +313,10 @@ std::string GameBoard::getMoveString(move_t move)
                         ", Jump: " + std::to_string(move.jumpPos));
 }
 
+// Set the board to a random state
+void GameBoard::scramble()
+{
+    //TODO: set game board to a random state
+}
+
 }

--- a/games/checkers/src/GameBoard.cpp
+++ b/games/checkers/src/GameBoard.cpp
@@ -316,7 +316,8 @@ std::string GameBoard::getMoveString(move_t move)
 // Set the board to a random state
 void GameBoard::scramble()
 {
-    //TODO: set game board to a random state
+    //TODO: set to random state
+    initBoard();  // placeholder
 }
 
 }


### PR DESCRIPTION
This PR contains the first optimization round for the simulation kernel. This changes the kernel from a thread pool design to a single sim/thread model. The intent with this change is to reduce the accesses to global memory by reducing the need for cross-thread synchronization. Each thread runs 1 simulation and returns the result at the end. This change can possibly benefit from thread coarsening at higher simulation loads. Attached are some metrics gathered against the previous iteration. 

Some notes on the metrics. The main ones to pay attention to are the turn execution time and simulation execution times. The throughput for the older iteration had some issues I think so it might not be accurate.

Additionally, I gathered some metrics to compare the hybrid MCTS to the PMCTS.
![ScreenshotForPR_Optimization1](https://user-images.githubusercontent.com/44873307/229943711-86b7fc88-a871-49c9-a098-29def417a6ca.png)
